### PR TITLE
ci docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Build Docker image
+        run: docker build -t karlicoss/cloudmacs:latest .
+
+      - name: Push Docker image to Docker Hub
+        run: docker push karlicoss/cloudmacs:latest


### PR DESCRIPTION
Fixes #9 
@karlicoss this will work if you could create access token from dockerhub and add to repo settings as secret variable and then this pipeline will work to automatically build and push the image.